### PR TITLE
Use newer package for the LayoutEditor

### DIFF
--- a/XtrkCadReader.java
+++ b/XtrkCadReader.java
@@ -29,7 +29,7 @@ public class XtrkCadReader {
 		"<!DOCTYPE layout-config SYSTEM \"layout-config.dtd\">\n" +
 		"<layout-config>\n<!--\n\nXtrkCadReader - XtrkCad to JMRI Layout Editor format conversion utility\n" +
 		"Revision 2.1\n";
-	static final String xml1 = "	<LayoutEditor class=\"jmri.jmrit.display.configurexml.LayoutEditorXml\" name=\"";
+	static final String xml1 = "	<LayoutEditor class=\"jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml\" name=\"";
 	static final String xml2 = "\" x=\"0\" y=\"0\" height=\"";
 	static final String xml3 = "\" width=\"";
 	static final String xml4 =	"\" editable=\"yes\" positionable=\"yes\" controlling=\"yes\" animating=\"yes\" " +


### PR DESCRIPTION
This newer package has been in place for years, so it should be possible to replace this without too much concern for backwards compatibility.

JMRI version 4.5 drops support for the older package name.
